### PR TITLE
Use express to serve static content and bypass BGG CORS restrictions

### DIFF
--- a/app/components/service/bggXMLApiService.js
+++ b/app/components/service/bggXMLApiService.js
@@ -8,9 +8,9 @@
     BGGXMLApiService.$inject = ['$resource', '$q', '$http', 'x2js'];
 
     function BGGXMLApiService($resource, $q, $http, x2js) {
-        var bggApi = 'https://www.boardgamegeek.com/xmlapi2';
-        var bggApiOld = 'https://www.boardgamegeek.com/xmlapi';
-        var bggMarketApi = 'https://boardgamegeek.com/geekmarket/api/v1';
+        var bggApi = 'http://localhost:8000/xmlapi2';
+        var bggApiOld = 'http://localhost:8000/xmlapi';
+        var bggMarketApi = 'http://localhost:8000/geekmarket/api/v1';
         var defaultParams = {};
         
         var bggMarketResourceActions = {

--- a/cors-fix.js
+++ b/cors-fix.js
@@ -1,0 +1,17 @@
+var express = require('express');
+var app = express();
+var request = require('request');
+
+var BGG_BASE_URL = 'https://www.boardgamegeek.com';
+
+app.use(express.static('app'));
+
+app.get(['/xmlapi2/*', '/xmlapi/*', '/geekmarket/*'], function(req, res) {
+  req.pipe(request('https://www.boardgamegeek.com' + req.url)).pipe(res);
+});
+
+app.listen(8000, function (err) {
+  console.log('\x1b[33mStarting up http-server, serving \x1b[36m./app');
+  console.log('\x1b[33mAvailable on:');
+  console.log('  \x1b[32mhttp://localhost:8000\x1b[0m');
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,484 @@
+{
+    "name": "angular-seed",
+    "version": "0.0.0",
+    "lockfileVersion": 1,
+    "dependencies": {
+        "accepts": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+            "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo="
+        },
+        "ajv": {
+            "version": "4.11.8",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+            "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY="
+        },
+        "array-flatten": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+            "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+        },
+        "asn1": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+            "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+        },
+        "assert-plus": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+            "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+        },
+        "asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+        },
+        "aws-sign2": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+            "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+        },
+        "aws4": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+            "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+        },
+        "bcrypt-pbkdf": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+            "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+            "optional": true
+        },
+        "boom": {
+            "version": "2.10.1",
+            "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+            "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
+        },
+        "bower": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.0.tgz",
+            "integrity": "sha1-Vdvr7wrZFVOC2enT5JfBNyNFtEo="
+        },
+        "caseless": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+        },
+        "co": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+        },
+        "combined-stream": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+            "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
+        },
+        "content-disposition": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+            "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+        },
+        "content-type": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+            "integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0="
+        },
+        "cookie": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+            "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+        },
+        "cookie-signature": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+            "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+        },
+        "cryptiles": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+            "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
+        },
+        "dashdash": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+                }
+            }
+        },
+        "debug": {
+            "version": "2.6.7",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
+            "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4="
+        },
+        "delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+        },
+        "depd": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+            "integrity": "sha1-4b2Cxqq2ztlluXuIsX7T5SjKGMM="
+        },
+        "destroy": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+            "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+        },
+        "ecc-jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+            "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+            "optional": true
+        },
+        "ee-first": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+            "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+        },
+        "encodeurl": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+            "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
+        },
+        "escape-html": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+        },
+        "etag": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
+            "integrity": "sha1-b2Ma7zNtbEY2K1F2QETOIWvjwFE="
+        },
+        "express": {
+            "version": "4.15.3",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.15.3.tgz",
+            "integrity": "sha1-urZdDwOqgMNYQIly/HAPkWlEtmI="
+        },
+        "extend": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+            "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+        },
+        "extsprintf": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+            "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
+        },
+        "finalhandler": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.3.tgz",
+            "integrity": "sha1-70fneVDpmXgOhgIqVg4yF+DQzIk="
+        },
+        "forever-agent": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+        },
+        "form-data": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+            "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE="
+        },
+        "forwarded": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
+            "integrity": "sha1-Ge+YdMSuHCl7zweP3mOgm2aoQ2M="
+        },
+        "fresh": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
+            "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44="
+        },
+        "getpass": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+                }
+            }
+        },
+        "har-schema": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+            "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
+        },
+        "har-validator": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+            "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio="
+        },
+        "hawk": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+            "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ="
+        },
+        "hoek": {
+            "version": "2.16.3",
+            "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+            "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+        },
+        "http-errors": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
+            "integrity": "sha1-X4uO2YrKVFZWv1cplzh/kEpyIlc="
+        },
+        "http-signature": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+            "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8="
+        },
+        "inherits": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "ipaddr.js": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.3.0.tgz",
+            "integrity": "sha1-HgOlL9rYOou7KyXL9JmLTP/NPew="
+        },
+        "is-typedarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+        },
+        "isstream": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+        },
+        "jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+            "optional": true
+        },
+        "json-schema": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+        },
+        "json-stable-stringify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+            "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8="
+        },
+        "json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+        },
+        "jsonify": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+        },
+        "jsprim": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+            "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+                }
+            }
+        },
+        "media-typer": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+            "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+        },
+        "merge-descriptors": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+            "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+        },
+        "methods": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+            "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+        },
+        "mime": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+            "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
+        },
+        "mime-db": {
+            "version": "1.27.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+            "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
+        },
+        "mime-types": {
+            "version": "2.1.15",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+            "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0="
+        },
+        "ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "negotiator": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+            "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+        },
+        "oauth-sign": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+            "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+        },
+        "on-finished": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+            "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc="
+        },
+        "parseurl": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+            "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY="
+        },
+        "path-to-regexp": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+            "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+        },
+        "performance-now": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+            "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+        },
+        "proxy-addr": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.4.tgz",
+            "integrity": "sha1-J+VF9pYKRKYn2bREZ+NcG2tM4vM="
+        },
+        "punycode": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+            "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        },
+        "qs": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+            "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+        },
+        "range-parser": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+            "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+        },
+        "request": {
+            "version": "2.81.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+            "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA="
+        },
+        "safe-buffer": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
+            "integrity": "sha512-aSLEDudu6OoRr/2rU609gRmnYboRLxgDG1z9o2Q0os7236FwvcqIOO8r8U5JUEwivZOhDaKlFO4SbPTJYyBEyQ=="
+        },
+        "send": {
+            "version": "0.15.3",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.15.3.tgz",
+            "integrity": "sha1-UBP5+ZAj31DRvZiSwZ4979HVMwk="
+        },
+        "serve-static": {
+            "version": "1.12.3",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.3.tgz",
+            "integrity": "sha1-n0uhni8wMMVH+K+ZEHg47DjVseI="
+        },
+        "setprototypeof": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+            "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+        },
+        "sntp": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+            "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
+        },
+        "sshpk": {
+            "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+            "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+                }
+            }
+        },
+        "statuses": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+            "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+        },
+        "stringstream": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+            "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+        },
+        "tough-cookie": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+            "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo="
+        },
+        "tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0="
+        },
+        "tweetnacl": {
+            "version": "0.14.5",
+            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+            "optional": true
+        },
+        "type-is": {
+            "version": "1.6.15",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
+            "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA="
+        },
+        "unpipe": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+        },
+        "utils-merge": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+            "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
+        },
+        "uuid": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+            "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
+        },
+        "vary": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
+            "integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc="
+        },
+        "verror": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+            "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw="
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,26 +1,24 @@
 {
-  "name": "angular-seed",
-  "private": true,
-  "version": "0.0.0",
-  "description": "A starter project for AngularJS",
-  "repository": "https://github.com/angular/angular-seed",
-  "license": "MIT",
-  "devDependencies": {
-    "bower": "^1.7.7",
-    "http-server": "^0.9.0"
-  },
-  "scripts": {
-    "postinstall": "bower install",
-
-    "update-deps": "npm update",
-    "postupdate-deps": "bower update",
-
-    "prestart": "npm install",
-    "start": "http-server -a localhost -p 8000 -c-1 ./app",
-
-    "preupdate-webdriver": "npm install",
-    "update-webdriver": "webdriver-manager update",
-
-    "update-index-async": "node -e \"var fs=require('fs'),indexFile='app/index-async.html',loaderFile='app/bower_components/angular-loader/angular-loader.min.js',loaderText=fs.readFileSync(loaderFile,'utf-8').split(/sourceMappingURL=angular-loader.min.js.map/).join('sourceMappingURL=bower_components/angular-loader/angular-loader.min.js.map'),indexText=fs.readFileSync(indexFile,'utf-8').split(/\\/\\/@@NG_LOADER_START@@[\\s\\S]*\\/\\/@@NG_LOADER_END@@/).join('//@@NG_LOADER_START@@\\n'+loaderText+'    //@@NG_LOADER_END@@');fs.writeFileSync(indexFile,indexText);\""
-  }
+    "name": "angular-seed",
+    "private": true,
+    "version": "0.0.0",
+    "description": "A starter project for AngularJS",
+    "repository": "https://github.com/angular/angular-seed",
+    "license": "MIT",
+    "devDependencies": {},
+    "scripts": {
+        "postinstall": "bower install",
+        "update-deps": "npm update",
+        "postupdate-deps": "bower update",
+        "prestart": "npm install",
+        "start": "node cors-fix.js",
+        "preupdate-webdriver": "npm install",
+        "update-webdriver": "webdriver-manager update",
+        "update-index-async": "node -e \"var fs=require('fs'),indexFile='app/index-async.html',loaderFile='app/bower_components/angular-loader/angular-loader.min.js',loaderText=fs.readFileSync(loaderFile,'utf-8').split(/sourceMappingURL=angular-loader.min.js.map/).join('sourceMappingURL=bower_components/angular-loader/angular-loader.min.js.map'),indexText=fs.readFileSync(indexFile,'utf-8').split(/\\/\\/@@NG_LOADER_START@@[\\s\\S]*\\/\\/@@NG_LOADER_END@@/).join('//@@NG_LOADER_START@@\\n'+loaderText+'    //@@NG_LOADER_END@@');fs.writeFileSync(indexFile,indexText);\""
+    },
+    "dependencies": {
+        "bower": "^1.8.0",
+        "express": "^4.15.3",
+        "request": "^2.81.0"
+    }
 }


### PR DESCRIPTION
Use express to proxy requests to bgg's API.  This eliminates CORs exceptions since only browsers care about the access headers.